### PR TITLE
Add kitspace.yml, improve READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The connections are not very stable which could produce reading errors. Wiring t
 All the electronics are easy to put together. The connections are stable and secure. You can quickly add connect more measurement cells.
 
 **Disadvantage:**
-Well.. you need the PCBs. But you can easily order them from a PCB manufacturer with the gerber files in this repository. You'll find more info about this in [/hardware/pcb/README.md](https://github.com/vektorious/test_tube_photometer/tree/master/hardware).
+Well.. you need the PCBs. But you can easily order them from a PCB manufacturer with the gerber files in this repository. You'll find more info about this in [/hardware/pcb/README.md](https://github.com/vektorious/test_tube_photometer/tree/master/hardware/pcb).
 
 Both ways of building the photometer are described [in the instructions folder](https://github.com/vektorious/test_tube_photometer/tree/master/instructions).
 

--- a/hardware/pcb/README.md
+++ b/hardware/pcb/README.md
@@ -1,6 +1,10 @@
-# Explaination
+# Test Tube Photometer PCBs
+
+For full project details see [the main README](https://github.com/vektorious/test_tube_photometer#readme).
 
 ## tt_nano_HAT_b1
+
+[Kitspace page](https://kitspace.org/boards/github.com/vektorious/test_tube_photometer/tt_nano_HAT_b1)
 
 First version of a Arduino Nano HAT to connect multiple photometer cells.
 It works BUT.
@@ -9,6 +13,8 @@ Problems:
 - jst connectors too close together
 
 ## tt_nano_HAT_b2
+
+[Kitspace page](https://kitspace.org/boards/github.com/vektorious/test_tube_photometer/tt_nano_HAT_b2)
 
 Second version of the Arduino Nano HAT.
 It looks better and works BUT.
@@ -19,6 +25,8 @@ Problems:
 (I'll never learn)
 
 ## opt101_module
+
+[Kitspace page](https://kitspace.org/boards/github.com/vektorious/test_tube_photometer/tt_opt101_module)
 
 PCB that fits the opt101 and a potentiometer to set the sensitivity of the sensor. Works great and fits perfectly into the housing of the measurement cells.
 

--- a/kitspace.yml
+++ b/kitspace.yml
@@ -1,0 +1,22 @@
+multi:
+  tt_nano_HAT_b1:
+    summary: Test Tube Photometer Arduino Nano HAT - Version 1
+    readme: hardware/pcb/README.md
+    bom: hardware/pcb/tt_nano_HAT_b1/1-click-bom.csv
+    eda:
+      type: kicad
+      pcb: hardware/pcb/tt_nano_HAT_b1/tt_nano_HAT_b1.kicad_pcb
+  tt_nano_HAT_b2:
+    summary: Test Tube Photometer Arduino Nano HAT - Version 2
+    readme: hardware/pcb/README.md
+    bom: hardware/pcb/tt_nano_HAT_b2/1-click-bom.csv
+    eda:
+      type: kicad
+      pcb: hardware/pcb/tt_nano_HAT_b2/tt_nano_HAT_b2.kicad_pcb
+  tt_opt101_module:
+    summary: Test Tube Photometer opt101 module.
+    readme: hardware/pcb/README.md
+    bom: hardware/pcb/tt_opt101_module_b1/tt_opt101_module_b1.kicad_pcb
+    eda:
+      type: kicad
+      pcb: hardware/pcb/tt_opt101_module_b1/tt_opt101_module_b1.kicad_pcb


### PR DESCRIPTION
Hi, this adds kitspace.yml to add your project to [kitspace.org](https://kitspace.org). I've made some tweaks to the readme files as well. The BOM for the opt101 module is generated directly from the .kicad_pcb. You could use the [bom-builder](https://kitspace.org/bom-builder) to make a better one. Do you have access to that? If not let me know and I'll send you a link. 

Here is a preview: http://try-test-tube-photometer.preview.kitspace.org/

If you are happy to add it just merge this. 